### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 A powerful and easy using keyboard lib includes emoticons, audio recording, multi media keyboard, etc.
 
 
-###Demo
+### Demo
 <div class='row'>
     <img src='http://7xq276.com2.z0.glb.qiniucdn.com/keyboard-demo.gif' width="250px"/>
 </div>
 
 [Apk Download](http://7xq276.com2.z0.glb.qiniucdn.com/keyboard.apk)
 
-###Import
+### Import
 
 use maven to import dependency in gradle
 
@@ -31,7 +31,7 @@ dependency
 com.android.support:support-v4:23.1.0
 ```
 
-###How to use
+### How to use
 
 1, Use ChatKeyboardLayout make your layout contains keyboard.
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
